### PR TITLE
Add version specifiers for dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-aiohttp
-lxml
-orjson
-requests
-tomli
+aiohttp~=3.8
+lxml~=4.7
+orjson~=3.6
+requests~=2.26
+tomli~=2.0

--- a/scripts/utils/async_funcs.py
+++ b/scripts/utils/async_funcs.py
@@ -32,6 +32,5 @@ async def get_json(course, session):
 
 
 def get_session():
-    session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=50))
-    session.headers.update({'User-Agent': 'Mozilla/5.0'})
+    session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=50), headers={'User-Agent': 'Mozilla/5.0'})
     return session


### PR DESCRIPTION
This adds compatible release specifiers for the dependencies, making
installing a working set of dependencies simpler.

The latest version of aiohttp (3.8.1) requires a minor code change which
has been included.