### PR TITLE
Fix "TypeError: File must be opened in binary mode" (Issue #101)

### DIFF
--- a/scripts/utils/settings.py
+++ b/scripts/utils/settings.py
@@ -39,7 +39,7 @@ class Settings:
             
     def open_file(self, file_path):
         if os.path.isfile(file_path):
-            return open(file_path, 'r')
+            return open(file_path, 'rb')
         print('OpenFileError: ', file_path)
         return None
     


### PR DESCRIPTION
I assume this is due to unpinned libraries and a newer tomli version
mandating the 'rb' mode.