### PR TITLE
Add support for gzipping output

### DIFF
--- a/settings/default_settings.toml
+++ b/settings/default_settings.toml
@@ -4,6 +4,7 @@
 # Intended as a backup only, use user_settings.toml 
 
 auto_update = true      # Check for updates to remote repo and automatically pull
+gzip_output = false     # If false save uncompressed .csv files, if true save compressed .csv.gz files
 
 [fields]
 

--- a/settings/user_settings.toml
+++ b/settings/user_settings.toml
@@ -6,6 +6,7 @@
 # the columns in the CSV. Just make sure each field name is not changed.
 
 auto_update = true      # Check for updates to remote repo and automatically pull
+gzip_output = false     # If false save uncompressed .csv files, if true save compressed .csv.gz files
 
 [fields]
 


### PR DESCRIPTION
If `gzip_output = true` in settings then downloaded data will be
compressed and stored as .csv.gz rather than plain uncompressed csv.

This setting is set to `false` by default to maintain backwards
compatiblity.